### PR TITLE
Add query params to supply summary endpoint

### DIFF
--- a/x/supply/client/rest/query.go
+++ b/x/supply/client/rest/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"strconv"
 
 	"github.com/gorilla/mux"
 
@@ -14,11 +15,6 @@ import (
 	"github.com/ovrclk/cosmos-supply-summary/x/supply/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-)
-
-var (
-	decimals float64 = 6
-	denom            = "uakt"
 )
 
 // RegisterRoutes registers all query routes
@@ -36,32 +32,49 @@ func circulatingSupplyHandler(ctx context.CLIContext) http.HandlerFunc {
 				return
 			}
 			rest.PostProcessResponse(w, ctx, res)
-		} else {
-			res, err := query.NewClient(ctx, types.ModuleName).CirculatingSupply()
-			if err != nil {
-				rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
-				return
-			}
-			metric := sdk.Coins{}
-			if q == "total" {
-				metric = res.Total
-			} else if q == "circulating" {
-				metric = res.Circulating
-			} else {
-				rest.WriteErrorResponse(w, http.StatusBadRequest, "wrong q value")
-				return
-			}
-			supply := sdk.Coin{}
-			for _, coin := range metric {
-				if coin.Denom == denom {
-					supply = coin
-				}
-			}
-			if supply.Denom == "" {
-				rest.WriteErrorResponse(w, http.StatusBadRequest, "no supply found with default denom")
-				return
-			}
-			fmt.Fprintf(w, "%.6f", float64(supply.Amount.Int64())/math.Pow(10, decimals))
+			return
 		}
+		denom := r.URL.Query().Get("denom")
+		decString := r.URL.Query().Get("decimal")
+		if len(denom) == 0 {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, "`denom` value is required")
+			return
+		}
+		if len(decString) == 0 {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, "`decimal` value is required")
+			return
+		}
+
+		decimals, err := strconv.ParseFloat(decString, 64)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		res, err := query.NewClient(ctx, types.ModuleName).CirculatingSupply()
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		metric := sdk.Coins{}
+		if q == "total" {
+			metric = res.Total
+		} else if q == "circulating" {
+			metric = res.Circulating
+		} else {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, "wrong query value, allowed values are `total`, `circulating`")
+			return
+		}
+		supply := sdk.Coin{}
+		for _, coin := range metric {
+			if coin.Denom == denom {
+				supply = coin
+			}
+		}
+		if supply.Denom == "" {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, "supply not found with given denom")
+			return
+		}
+		fmt.Fprintf(w, "%.6f", float64(supply.Amount.Int64())/math.Pow(10, decimals))
 	}
 }

--- a/x/supply/client/rest/query.go
+++ b/x/supply/client/rest/query.go
@@ -1,6 +1,8 @@
 package rest
 
 import (
+	"fmt"
+	"math"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -10,6 +12,13 @@ import (
 
 	"github.com/ovrclk/cosmos-supply-summary/x/supply/query"
 	"github.com/ovrclk/cosmos-supply-summary/x/supply/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var (
+	decimals float64 = 6
+	denom            = "uakt"
 )
 
 // RegisterRoutes registers all query routes
@@ -19,11 +28,40 @@ func RegisterRoutes(ctx context.CLIContext, r *mux.Router) {
 
 func circulatingSupplyHandler(ctx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		res, err := query.NewRawClient(ctx, types.ModuleName).CirculatingSupply()
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
-			return
+		q := r.URL.Query().Get("q")
+		if len(q) == 0 {
+			res, err := query.NewRawClient(ctx, types.ModuleName).CirculatingSupply()
+			if err != nil {
+				rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			rest.PostProcessResponse(w, ctx, res)
+		} else {
+			res, err := query.NewClient(ctx, types.ModuleName).CirculatingSupply()
+			if err != nil {
+				rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			metric := sdk.Coins{}
+			if q == "total" {
+				metric = res.Total
+			} else if q == "circulating" {
+				metric = res.Circulating
+			} else {
+				rest.WriteErrorResponse(w, http.StatusBadRequest, "wrong q value")
+				return
+			}
+			supply := sdk.Coin{}
+			for _, coin := range metric {
+				if coin.Denom == denom {
+					supply = coin
+				}
+			}
+			if supply.Denom == "" {
+				rest.WriteErrorResponse(w, http.StatusBadRequest, "no supply found with default denom")
+				return
+			}
+			fmt.Fprintf(w, "%.6f", float64(supply.Amount.Int64())/math.Pow(10, decimals))
 		}
-		rest.PostProcessResponse(w, ctx, res)
 	}
 }


### PR DESCRIPTION
- Fullfil CMC's API requirements. The old supply summary endpoint now takes optional `query` parameters to filter and send the required details. Optional query parameters are:
`q` => `total` or `circulating`
`denom` => denom to filter the amount (required if `q` is supplied)
`decimals` => decimals to convert the tokens (required if `q` is supplied)